### PR TITLE
Fixed title sizing for smaller screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,3 +124,10 @@ button {
     cursor: pointer;
     margin: 5px;
 }
+
+/* Specific breakpoint for title */
+@media only screen and (max-width: 1070px){
+    .title {
+        font-size: 10em;
+    }
+} 


### PR DESCRIPTION
Added a media query at the end of style.css specific to the breakpoint for the title, and resized the title to fit for screen sizes smaller than the breakpoint